### PR TITLE
Add helper to retrieve correct vout from TxOut value

### DIFF
--- a/src/protocol/transaction_ext.rs
+++ b/src/protocol/transaction_ext.rs
@@ -4,6 +4,7 @@ use bdk::bitcoin::{OutPoint, Script, Transaction};
 pub trait TransactionExt {
     fn get_virtual_size(&self) -> f64;
     fn outpoint(&self, script_pubkey: &Script) -> Result<OutPoint>;
+    fn outpoint_of_value(&self, value: u64) -> Result<OutPoint>;
 }
 
 impl TransactionExt for Transaction {
@@ -17,6 +18,19 @@ impl TransactionExt for Transaction {
             .iter()
             .position(|out| &out.script_pubkey == script_pubkey)
             .context("script pubkey not found in tx")?;
+
+        Ok(OutPoint {
+            txid: self.txid(),
+            vout: vout as u32,
+        })
+    }
+
+    fn outpoint_of_value(&self, value: u64) -> Result<Outpoint> {
+        let vout = self
+            .output
+            .iter()
+            .position(|out| &out.value == value)
+            .context("value not found in tx")?;
 
         Ok(OutPoint {
             txid: self.txid(),


### PR DESCRIPTION
At times we don't have access to script pubkey, and need to find the correct
vout based on the output amount.