### PR TITLE
Revert "Rename {maker,taker} to {long,short}"

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -14,10 +14,10 @@
     "**/node_modules"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/markdown-0.9.2.wasm",
-    "https://plugins.dprint.dev/rustfmt-0.4.0.exe-plugin@c6bb223ef6e5e87580177f6461a0ab0554ac9ea6b54f78ea7ae8bf63b14f5bc2",
-    "https://plugins.dprint.dev/toml-0.4.0.wasm"
-    "https://plugins.dprint.dev/typescript-0.35.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.13.0.wasm",
+    "https://plugins.dprint.dev/rustfmt-0.6.1.exe-plugin@99b89a0599fd3a63e597e03436862157901f3facae2f0c2fbd0b9f656cdbc2a5",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm",
+    "https://plugins.dprint.dev/typescript-0.66.0.wasm",
     "https://plugins.dprint.dev/json-0.7.2.wasm"
   ]
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -58,10 +58,10 @@ where
 ///
 /// # Arguments
 ///
-/// * `long` - The initial parameters of the party going long.
-/// * `long_punish_params` - The punish parameters of the party going long.
-/// * `short` - The initial parameters of the party going short.
-/// * `short_punish_params` - The punish parameters of the party going short.
+/// * `maker` - The initial parameters of the maker.
+/// * `maker_punish_params` - The punish parameters of the maker.
+/// * `taker` - The initial parameters of the taker.
+/// * `taker_punish_params` - The punish parameters of the taker.
 /// * `oracle_pk` - The public key of the oracle.
 /// * `cet_timelock` - Relative timelock of the CET transaction with respect to the commit
 ///   transaction.
@@ -71,8 +71,8 @@ where
 ///   the conditions of the bet. The key is the event at which the oracle will attest the price.
 /// * `identity_sk` - The secret key of the caller, used to sign and encsign different transactions.
 pub fn create_cfd_transactions(
-    (long, long_punish_params): (PartyParams, PunishParams),
-    (short, short_punish_params): (PartyParams, PunishParams),
+    (maker, maker_punish_params): (PartyParams, PunishParams),
+    (taker, taker_punish_params): (PartyParams, PunishParams),
     oracle_pk: schnorrsig::PublicKey,
     (cet_timelock, refund_timelock): (u32, u32),
     payouts_per_event: HashMap<Announcement, Vec<Payout>>,
@@ -80,26 +80,26 @@ pub fn create_cfd_transactions(
     commit_tx_fee_rate: u32,
 ) -> Result<CfdTransactions> {
     let lock_tx = lock_transaction(
-        long.lock_psbt.clone(),
-        short.lock_psbt.clone(),
-        long.identity_pk,
-        short.identity_pk,
-        long.lock_amount + short.lock_amount,
+        maker.lock_psbt.clone(),
+        taker.lock_psbt.clone(),
+        maker.identity_pk,
+        taker.identity_pk,
+        maker.lock_amount + taker.lock_amount,
     );
 
     build_cfds(
         lock_tx,
         (
-            long.identity_pk,
-            long.lock_amount,
-            long.address,
-            long_punish_params,
+            maker.identity_pk,
+            maker.lock_amount,
+            maker.address,
+            maker_punish_params,
         ),
         (
-            short.identity_pk,
-            short.lock_amount,
-            short.address,
-            short_punish_params,
+            taker.identity_pk,
+            taker.lock_amount,
+            taker.address,
+            taker_punish_params,
         ),
         oracle_pk,
         (cet_timelock, refund_timelock),
@@ -112,13 +112,13 @@ pub fn create_cfd_transactions(
 #[allow(clippy::too_many_arguments)]
 pub fn renew_cfd_transactions(
     lock_tx: PartiallySignedTransaction,
-    (long_pk, long_lock_amount, long_address, long_punish_params): (
+    (maker_pk, maker_lock_amount, maker_address, maker_punish_params): (
         PublicKey,
         Amount,
         Address,
         PunishParams,
     ),
-    (short_pk, short_lock_amount, short_address, short_punish_params): (
+    (taker_pk, taker_lock_amount, taker_address, taker_punish_params): (
         PublicKey,
         Amount,
         Address,
@@ -132,12 +132,17 @@ pub fn renew_cfd_transactions(
 ) -> Result<CfdTransactions> {
     build_cfds(
         lock_tx,
-        (long_pk, long_lock_amount, long_address, long_punish_params),
         (
-            short_pk,
-            short_lock_amount,
-            short_address,
-            short_punish_params,
+            maker_pk,
+            maker_lock_amount,
+            maker_address,
+            maker_punish_params,
+        ),
+        (
+            taker_pk,
+            taker_lock_amount,
+            taker_address,
+            taker_punish_params,
         ),
         oracle_pk,
         (cet_timelock, refund_timelock),
@@ -150,13 +155,13 @@ pub fn renew_cfd_transactions(
 #[allow(clippy::too_many_arguments)]
 fn build_cfds(
     lock_tx: PartiallySignedTransaction,
-    (long_pk, long_lock_amount, long_address, long_punish_params): (
+    (maker_pk, maker_lock_amount, maker_address, maker_punish_params): (
         PublicKey,
         Amount,
         Address,
         PunishParams,
     ),
-    (short_pk, short_lock_amount, short_address, short_punish_params): (
+    (taker_pk, taker_lock_amount, taker_address, taker_punish_params): (
         PublicKey,
         Amount,
         Address,
@@ -171,36 +176,36 @@ fn build_cfds(
     let commit_tx = CommitTransaction::new(
         &lock_tx.global.unsigned_tx,
         (
-            long_pk,
-            long_punish_params.revocation_pk,
-            long_punish_params.publish_pk,
+            maker_pk,
+            maker_punish_params.revocation_pk,
+            maker_punish_params.publish_pk,
         ),
         (
-            short_pk,
-            short_punish_params.revocation_pk,
-            short_punish_params.publish_pk,
+            taker_pk,
+            taker_punish_params.revocation_pk,
+            taker_punish_params.publish_pk,
         ),
         commit_tx_fee_rate,
     )
     .context("cannot build commit tx")?;
 
     let identity_pk = secp256k1_zkp::PublicKey::from_secret_key(SECP256K1, &identity_sk);
-    let commit_encsig = if identity_pk == long_pk.key {
-        commit_tx.encsign(identity_sk, &short_punish_params.publish_pk)
-    } else if identity_pk == short_pk.key {
-        commit_tx.encsign(identity_sk, &long_punish_params.publish_pk)
+    let commit_encsig = if identity_pk == maker_pk.key {
+        commit_tx.encsign(identity_sk, &taker_punish_params.publish_pk)
+    } else if identity_pk == taker_pk.key {
+        commit_tx.encsign(identity_sk, &maker_punish_params.publish_pk)
     } else {
-        bail!("identity sk does not belong to short or long")
+        bail!("identity sk does not belong to taker or maker")
     };
 
     let refund = {
         let tx = RefundTransaction::new(
             &commit_tx,
             refund_timelock,
-            &long_address,
-            &short_address,
-            long_lock_amount,
-            short_lock_amount,
+            &maker_address,
+            &taker_address,
+            maker_lock_amount,
+            taker_lock_amount,
         );
 
         let sighash = tx.sighash().to_message();
@@ -218,8 +223,8 @@ fn build_cfds(
                     let cet = ContractExecutionTx::new(
                         &commit_tx,
                         payout.clone(),
-                        &long_address,
-                        &short_address,
+                        &maker_address,
+                        &taker_address,
                         event.nonce_pks.as_slice(),
                         cet_timelock,
                     )?;
@@ -243,15 +248,15 @@ fn build_cfds(
     })
 }
 
-pub fn lock_descriptor(long_pk: PublicKey, short_pk: PublicKey) -> Descriptor<PublicKey> {
+pub fn lock_descriptor(maker_pk: PublicKey, taker_pk: PublicKey) -> Descriptor<PublicKey> {
     const MINISCRIPT_TEMPLATE: &str = "c:and_v(v:pk(A),pk_k(B))";
 
-    let long_pk = ToHex::to_hex(&long_pk.key);
-    let short_pk = ToHex::to_hex(&short_pk.key);
+    let maker_pk = ToHex::to_hex(&maker_pk.key);
+    let taker_pk = ToHex::to_hex(&taker_pk.key);
 
     let miniscript = MINISCRIPT_TEMPLATE
-        .replace('A', &long_pk)
-        .replace('B', &short_pk);
+        .replace('A', &maker_pk)
+        .replace('B', &taker_pk);
 
     let miniscript = miniscript.parse().expect("a valid miniscript");
 
@@ -259,31 +264,31 @@ pub fn lock_descriptor(long_pk: PublicKey, short_pk: PublicKey) -> Descriptor<Pu
 }
 
 pub fn commit_descriptor(
-    (long_own_pk, long_rev_pk, long_publish_pk): (PublicKey, PublicKey, PublicKey),
-    (short_own_pk, short_rev_pk, short_publish_pk): (PublicKey, PublicKey, PublicKey),
+    (maker_own_pk, maker_rev_pk, maker_publish_pk): (PublicKey, PublicKey, PublicKey),
+    (taker_own_pk, taker_rev_pk, taker_publish_pk): (PublicKey, PublicKey, PublicKey),
 ) -> Descriptor<PublicKey> {
-    let long_own_pk_hash = long_own_pk.pubkey_hash().as_hash();
-    let long_own_pk = long_own_pk.key.serialize().to_hex();
-    let long_publish_pk_hash = long_publish_pk.pubkey_hash().as_hash();
-    let long_rev_pk_hash = long_rev_pk.pubkey_hash().as_hash();
+    let maker_own_pk_hash = maker_own_pk.pubkey_hash().as_hash();
+    let maker_own_pk = maker_own_pk.key.serialize().to_hex();
+    let maker_publish_pk_hash = maker_publish_pk.pubkey_hash().as_hash();
+    let maker_rev_pk_hash = maker_rev_pk.pubkey_hash().as_hash();
 
-    let short_own_pk_hash = short_own_pk.pubkey_hash().as_hash();
-    let short_own_pk = short_own_pk.key.serialize().to_hex();
-    let short_publish_pk_hash = short_publish_pk.pubkey_hash().as_hash();
-    let short_rev_pk_hash = short_rev_pk.pubkey_hash().as_hash();
+    let taker_own_pk_hash = taker_own_pk.pubkey_hash().as_hash();
+    let taker_own_pk = taker_own_pk.key.serialize().to_hex();
+    let taker_publish_pk_hash = taker_publish_pk.pubkey_hash().as_hash();
+    let taker_rev_pk_hash = taker_rev_pk.pubkey_hash().as_hash();
 
     // raw script:
-    // or(and(pk(long_own_pk),pk(short_own_pk)),or(and(pk(long_own_pk),and(pk(short_publish_pk),
-    // pk(short_rev_pk))),and(pk(short_own_pk),and(pk(long_publish_pk),pk(long_rev_pk)))))
-    let full_script = format!("wsh(c:andor(pk({long_own_pk}),pk_k({short_own_pk}),or_i(and_v(v:pkh({long_own_pk_hash}),and_v(v:pkh({short_publish_pk_hash}),pk_h({short_rev_pk_hash}))),and_v(v:pkh({short_own_pk_hash}),and_v(v:pkh({long_publish_pk_hash}),pk_h({long_rev_pk_hash}))))))",
-long_own_pk = long_own_pk,
-short_own_pk = short_own_pk,
-long_own_pk_hash = long_own_pk_hash,
-short_own_pk_hash = short_own_pk_hash,
-short_publish_pk_hash = short_publish_pk_hash,
-short_rev_pk_hash = short_rev_pk_hash,
-long_publish_pk_hash = long_publish_pk_hash,
-long_rev_pk_hash = long_rev_pk_hash
+    // or(and(pk(maker_own_pk),pk(taker_own_pk)),or(and(pk(maker_own_pk),and(pk(taker_publish_pk),
+    // pk(taker_rev_pk))),and(pk(taker_own_pk),and(pk(maker_publish_pk),pk(maker_rev_pk)))))
+    let full_script = format!("wsh(c:andor(pk({maker_own_pk}),pk_k({taker_own_pk}),or_i(and_v(v:pkh({maker_own_pk_hash}),and_v(v:pkh({taker_publish_pk_hash}),pk_h({taker_rev_pk_hash}))),and_v(v:pkh({taker_own_pk_hash}),and_v(v:pkh({maker_publish_pk_hash}),pk_h({maker_rev_pk_hash}))))))",
+        maker_own_pk = maker_own_pk,
+        taker_own_pk = taker_own_pk,
+        maker_own_pk_hash = maker_own_pk_hash,
+        taker_own_pk_hash = taker_own_pk_hash,
+        taker_publish_pk_hash = taker_publish_pk_hash,
+        taker_rev_pk_hash = taker_rev_pk_hash,
+        maker_publish_pk_hash = maker_publish_pk_hash,
+        maker_rev_pk_hash = maker_rev_pk_hash
     );
 
     full_script.parse().expect("a valid miniscript")
@@ -381,22 +386,22 @@ impl PartialEq for Announcement {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Payout {
     digits: interval::Digits,
-    long_amount: Amount,
-    short_amount: Amount,
+    maker_amount: Amount,
+    taker_amount: Amount,
 }
 
 pub fn generate_payouts(
     range: RangeInclusive<u64>,
-    long_amount: Amount,
-    short_amount: Amount,
+    maker_amount: Amount,
+    taker_amount: Amount,
 ) -> Result<Vec<Payout>> {
     let digits = interval::Digits::new(range).context("invalid interval")?;
     Ok(digits
         .into_iter()
         .map(|digits| Payout {
             digits,
-            long_amount,
-            short_amount,
+            maker_amount,
+            taker_amount,
         })
         .collect())
 }
@@ -406,18 +411,18 @@ impl Payout {
         &self.digits
     }
 
-    pub fn long_amount(&self) -> &Amount {
-        &self.long_amount
+    pub fn maker_amount(&self) -> &Amount {
+        &self.maker_amount
     }
 
-    pub fn short_amount(&self) -> &Amount {
-        &self.short_amount
+    pub fn taker_amount(&self) -> &Amount {
+        &self.taker_amount
     }
 
-    fn into_txouts(self, long_address: &Address, short_address: &Address) -> Vec<TxOut> {
+    fn into_txouts(self, maker_address: &Address, taker_address: &Address) -> Vec<TxOut> {
         let txouts = [
-            (self.long_amount, long_address),
-            (self.short_amount, short_address),
+            (self.maker_amount, maker_address),
+            (self.taker_amount, taker_address),
         ]
         .iter()
         .filter_map(|(amount, address)| {
@@ -441,34 +446,34 @@ impl Payout {
     fn with_updated_fee(
         self,
         fee: Amount,
-        dust_limit_long: Amount,
-        dust_limit_short: Amount,
+        dust_limit_maker: Amount,
+        dust_limit_taker: Amount,
     ) -> Result<Self> {
-        let long_amount = self.long_amount;
-        let short_amount = self.short_amount;
+        let maker_amount = self.maker_amount;
+        let taker_amount = self.taker_amount;
 
         let mut updated = self;
         match (
-            long_amount
+            maker_amount
                 .checked_sub(fee / 2)
-                .map(|a| a > dust_limit_long)
+                .map(|a| a > dust_limit_maker)
                 .unwrap_or(false),
-            short_amount
+            taker_amount
                 .checked_sub(fee / 2)
-                .map(|a| a > dust_limit_short)
+                .map(|a| a > dust_limit_taker)
                 .unwrap_or(false),
         ) {
             (true, true) => {
-                updated.long_amount -= fee / 2;
-                updated.short_amount -= fee / 2;
+                updated.maker_amount -= fee / 2;
+                updated.taker_amount -= fee / 2;
             }
             (false, true) => {
-                updated.long_amount = Amount::ZERO;
-                updated.short_amount = short_amount - (fee + long_amount);
+                updated.maker_amount = Amount::ZERO;
+                updated.taker_amount = taker_amount - (fee + maker_amount);
             }
             (true, false) => {
-                updated.long_amount = long_amount - (fee + short_amount);
-                updated.short_amount = Amount::ZERO;
+                updated.maker_amount = maker_amount - (fee + taker_amount);
+                updated.taker_amount = Amount::ZERO;
             }
             (false, false) => bail!("Amounts are too small, could not subtract fee."),
         }
@@ -507,12 +512,12 @@ mod tests {
         let dummy_address = Address::p2wpkh(&key, Network::Regtest).unwrap();
         let dummy_dust_limit = dummy_address.script_pubkey().dust_value();
 
-        let orig_long_amount = 1000;
-        let orig_short_amount = 1000;
+        let orig_maker_amount = 1000;
+        let orig_taker_amount = 1000;
         let payouts = generate_payouts(
             0..=10_000,
-            Amount::from_sat(orig_long_amount),
-            Amount::from_sat(orig_short_amount),
+            Amount::from_sat(orig_maker_amount),
+            Amount::from_sat(orig_taker_amount),
         )
         .unwrap();
         let fee = 100;
@@ -523,12 +528,12 @@ mod tests {
                 .unwrap();
 
             assert_eq!(
-                updated_payout.long_amount,
-                Amount::from_sat(orig_long_amount - fee / 2)
+                updated_payout.maker_amount,
+                Amount::from_sat(orig_maker_amount - fee / 2)
             );
             assert_eq!(
-                updated_payout.short_amount,
-                Amount::from_sat(orig_short_amount - fee / 2)
+                updated_payout.taker_amount,
+                Amount::from_sat(orig_taker_amount - fee / 2)
             );
         }
     }
@@ -541,12 +546,12 @@ mod tests {
         let dummy_address = Address::p2wpkh(&key, Network::Regtest).unwrap();
         let dummy_dust_limit = dummy_address.script_pubkey().dust_value();
 
-        let orig_long_amount = dummy_dust_limit.as_sat() - 1;
-        let orig_short_amount = 1000;
+        let orig_maker_amount = dummy_dust_limit.as_sat() - 1;
+        let orig_taker_amount = 1000;
         let payouts = generate_payouts(
             0..=10_000,
-            Amount::from_sat(orig_long_amount),
-            Amount::from_sat(orig_short_amount),
+            Amount::from_sat(orig_maker_amount),
+            Amount::from_sat(orig_taker_amount),
         )
         .unwrap();
         let fee = 100;
@@ -556,10 +561,10 @@ mod tests {
                 .with_updated_fee(Amount::from_sat(fee), dummy_dust_limit, dummy_dust_limit)
                 .unwrap();
 
-            assert_eq!(updated_payout.long_amount, Amount::from_sat(0));
+            assert_eq!(updated_payout.maker_amount, Amount::from_sat(0));
             assert_eq!(
-                updated_payout.short_amount,
-                Amount::from_sat(orig_short_amount - (fee + orig_long_amount))
+                updated_payout.taker_amount,
+                Amount::from_sat(orig_taker_amount - (fee + orig_maker_amount))
             );
         }
     }

--- a/src/protocol/transactions.rs
+++ b/src/protocol/transactions.rs
@@ -22,15 +22,15 @@ use std::num::NonZeroU8;
 const SATS_PER_VBYTE: f64 = 1.0;
 
 pub(crate) fn lock_transaction(
-    long_psbt: PartiallySignedTransaction,
-    short_psbt: PartiallySignedTransaction,
-    long_pk: PublicKey,
-    short_pk: PublicKey,
+    maker_psbt: PartiallySignedTransaction,
+    taker_psbt: PartiallySignedTransaction,
+    maker_pk: PublicKey,
+    taker_pk: PublicKey,
     amount: Amount,
 ) -> PartiallySignedTransaction {
-    let lock_descriptor = lock_descriptor(long_pk, short_pk);
+    let lock_descriptor = lock_descriptor(maker_pk, taker_pk);
 
-    let long_change = long_psbt
+    let maker_change = maker_psbt
         .global
         .unsigned_tx
         .output
@@ -40,7 +40,7 @@ pub(crate) fn lock_transaction(
         })
         .collect::<Vec<_>>();
 
-    let short_change = short_psbt
+    let taker_change = taker_psbt
         .global
         .unsigned_tx
         .output
@@ -56,14 +56,14 @@ pub(crate) fn lock_transaction(
     };
 
     let input = vec![
-        long_psbt.global.unsigned_tx.input,
-        short_psbt.global.unsigned_tx.input,
+        maker_psbt.global.unsigned_tx.input,
+        taker_psbt.global.unsigned_tx.input,
     ]
     .concat();
 
     let output = std::iter::once(lock_output)
-        .chain(long_change)
-        .chain(short_change)
+        .chain(maker_change)
+        .chain(taker_change)
         .collect();
 
     let lock_tx = Transaction {
@@ -75,8 +75,8 @@ pub(crate) fn lock_transaction(
 
     PartiallySignedTransaction {
         global: Global::from_unsigned_tx(lock_tx).expect("to be unsigned"),
-        inputs: vec![long_psbt.inputs, short_psbt.inputs].concat(),
-        outputs: vec![long_psbt.outputs, short_psbt.outputs].concat(),
+        inputs: vec![maker_psbt.inputs, taker_psbt.inputs].concat(),
+        outputs: vec![maker_psbt.outputs, taker_psbt.outputs].concat(),
     }
 }
 
@@ -96,11 +96,11 @@ impl CommitTransaction {
 
     pub(crate) fn new(
         lock_tx: &Transaction,
-        (long_pk, long_rev_pk, long_publish_pk): (PublicKey, PublicKey, PublicKey),
-        (short_pk, short_rev_pk, short_publish_pk): (PublicKey, PublicKey, PublicKey),
+        (maker_pk, maker_rev_pk, maker_publish_pk): (PublicKey, PublicKey, PublicKey),
+        (taker_pk, taker_rev_pk, taker_publish_pk): (PublicKey, PublicKey, PublicKey),
         fee_rate: u32,
     ) -> Result<Self> {
-        let lock_descriptor = lock_descriptor(long_pk, short_pk);
+        let lock_descriptor = lock_descriptor(maker_pk, taker_pk);
         let (lock_outpoint, lock_amount) = {
             let outpoint = lock_tx
                 .outpoint(&lock_descriptor.script_pubkey())
@@ -116,8 +116,8 @@ impl CommitTransaction {
         };
 
         let descriptor = commit_descriptor(
-            (long_pk, long_rev_pk, long_publish_pk),
-            (short_pk, short_rev_pk, short_publish_pk),
+            (maker_pk, maker_rev_pk, maker_publish_pk),
+            (taker_pk, taker_rev_pk, taker_publish_pk),
         );
 
         let output = TxOut {
@@ -203,8 +203,8 @@ impl ContractExecutionTransaction {
     pub(crate) fn new(
         commit_tx: &CommitTransaction,
         payout: Payout,
-        long_address: &Address,
-        short_address: &Address,
+        maker_address: &Address,
+        taker_address: &Address,
         nonce_pks: &[schnorrsig::PublicKey],
         relative_timelock_in_blocks: u32,
     ) -> Result<Self> {
@@ -225,10 +225,10 @@ impl ContractExecutionTransaction {
         let output = payout
             .with_updated_fee(
                 Amount::from_sat(fee.as_u64()),
-                long_address.script_pubkey().dust_value(),
-                short_address.script_pubkey().dust_value(),
+                maker_address.script_pubkey().dust_value(),
+                taker_address.script_pubkey().dust_value(),
             )?
-            .into_txouts(long_address, short_address);
+            .into_txouts(maker_address, taker_address);
 
         let tx = Transaction {
             version: 2,
@@ -285,10 +285,10 @@ impl RefundTransaction {
     pub(crate) fn new(
         commit_tx: &CommitTransaction,
         relative_locktime_in_blocks: u32,
-        long_address: &Address,
-        short_address: &Address,
-        long_amount: Amount,
-        short_amount: Amount,
+        maker_address: &Address,
+        taker_address: &Address,
+        maker_amount: Amount,
+        taker_amount: Amount,
     ) -> Self {
         let commit_input = TxIn {
             previous_output: commit_tx.outpoint(),
@@ -296,21 +296,21 @@ impl RefundTransaction {
             ..Default::default()
         };
 
-        let long_output = TxOut {
-            value: long_amount.as_sat(),
-            script_pubkey: long_address.script_pubkey(),
+        let maker_output = TxOut {
+            value: maker_amount.as_sat(),
+            script_pubkey: maker_address.script_pubkey(),
         };
 
-        let short_output = TxOut {
-            value: short_amount.as_sat(),
-            script_pubkey: short_address.script_pubkey(),
+        let taker_output = TxOut {
+            value: taker_amount.as_sat(),
+            script_pubkey: taker_address.script_pubkey(),
         };
 
         let mut tx = Transaction {
             version: 2,
             lock_time: 0,
             input: vec![commit_input],
-            output: vec![long_output, short_output],
+            output: vec![maker_output, taker_output],
         };
 
         let mut fee = Self::SIGNED_VBYTES * SATS_PER_VBYTE;
@@ -340,14 +340,14 @@ impl RefundTransaction {
 /// Build a transaction which closes the CFD contract.
 ///
 /// This transaction spends directly from the lock transaction. Both
-/// parties must agree on the split of coins between `long_amount`
-/// and `short_amount`.
+/// parties must agree on the split of coins between `maker_amount`
+/// and `taker_amount`.
 pub fn close_transaction(
     lock_descriptor: &Descriptor<PublicKey>,
     lock_outpoint: OutPoint,
     lock_amount: Amount,
-    (long_address, long_amount): (&Address, Amount),
-    (short_address, short_amount): (&Address, Amount),
+    (maker_address, maker_amount): (&Address, Amount),
+    (taker_address, taker_amount): (&Address, Amount),
     fee_rate: u32,
 ) -> Result<(Transaction, secp256k1_zkp::Message)> {
     /// Expected size of signed transaction in virtual bytes, plus a
@@ -362,22 +362,22 @@ pub fn close_transaction(
     // TODO: The fee could take into account the network state in this
     // case, since this transaction is to be broadcast immediately
     // after building and signing it
-    let (long_fee, short_fee) = Fee::new(SIGNED_VBYTES, fee_rate as f64).split();
+    let (maker_fee, taker_fee) = Fee::new(SIGNED_VBYTES, fee_rate as f64).split();
 
-    let long_output = TxOut {
-        value: long_amount.as_sat() - long_fee,
-        script_pubkey: long_address.script_pubkey(),
+    let maker_output = TxOut {
+        value: maker_amount.as_sat() - maker_fee,
+        script_pubkey: maker_address.script_pubkey(),
     };
-    let short_output = TxOut {
-        value: short_amount.as_sat() - short_fee,
-        script_pubkey: short_address.script_pubkey(),
+    let taker_output = TxOut {
+        value: taker_amount.as_sat() - taker_fee,
+        script_pubkey: taker_address.script_pubkey(),
     };
 
     let tx = Transaction {
         version: 2,
         lock_time: 0,
         input: vec![lock_input],
-        output: vec![long_output, short_output],
+        output: vec![maker_output, taker_output],
     };
 
     let sighash = SigHashCache::new(&tx)
@@ -528,10 +528,10 @@ mod tests {
         #[test]
         fn test_fee_always_above_min_relay_fee(signed_vbytes in 1.0f64..100_000_000.0f64) {
             let fee = Fee::new_with_default_rate(signed_vbytes);
-            let (long_fee, short_fee) = fee.split();
+            let (maker_fee, taker_fee) = fee.split();
 
             prop_assert!(signed_vbytes <= fee.as_u64() as f64);
-            prop_assert!(signed_vbytes <= (long_fee + short_fee) as f64);
+            prop_assert!(signed_vbytes <= (maker_fee + taker_fee) as f64);
         }
     }
 
@@ -542,12 +542,12 @@ mod tests {
         const SIGNED_VBYTES_TEST: f64 = 1.0;
 
         let fee = Fee::new_with_default_rate(SIGNED_VBYTES_TEST);
-        let (long_fee, short_fee) = fee.split();
+        let (maker_fee, taker_fee) = fee.split();
 
         assert_eq!(fee.as_u64(), 1);
-        assert_eq!(long_fee, 0);
-        assert_eq!(short_fee, 1);
-        assert!((long_fee + short_fee) as f64 >= SIGNED_VBYTES_TEST);
+        assert_eq!(maker_fee, 0);
+        assert_eq!(taker_fee, 1);
+        assert!((maker_fee + taker_fee) as f64 >= SIGNED_VBYTES_TEST);
     }
 
     #[test]
@@ -555,12 +555,12 @@ mod tests {
         const SIGNED_VBYTES_TEST: f64 = 2.0;
 
         let fee = Fee::new_with_default_rate(SIGNED_VBYTES_TEST);
-        let (long_fee, short_fee) = fee.split();
+        let (maker_fee, taker_fee) = fee.split();
 
         assert_eq!(fee.as_u64(), 2);
-        assert_eq!(long_fee, 1);
-        assert_eq!(short_fee, 1);
-        assert!((long_fee + short_fee) as f64 >= SIGNED_VBYTES_TEST);
+        assert_eq!(maker_fee, 1);
+        assert_eq!(taker_fee, 1);
+        assert!((maker_fee + taker_fee) as f64 >= SIGNED_VBYTES_TEST);
     }
 
     #[test]
@@ -568,12 +568,12 @@ mod tests {
         const SIGNED_VBYTES_TEST: f64 = 2.1;
 
         let fee = Fee::new_with_default_rate(SIGNED_VBYTES_TEST);
-        let (long_fee, short_fee) = fee.split();
+        let (maker_fee, taker_fee) = fee.split();
 
         assert_eq!(fee.as_u64(), 3);
-        assert_eq!(long_fee, 1);
-        assert_eq!(short_fee, 2);
-        assert!((long_fee + short_fee) as f64 >= SIGNED_VBYTES_TEST);
+        assert_eq!(maker_fee, 1);
+        assert_eq!(taker_fee, 2);
+        assert!((maker_fee + taker_fee) as f64 >= SIGNED_VBYTES_TEST);
     }
 
     #[test]
@@ -581,11 +581,11 @@ mod tests {
         const SIGNED_VBYTES_TEST: f64 = 2.6;
 
         let fee = Fee::new_with_default_rate(SIGNED_VBYTES_TEST);
-        let (long_fee, short_fee) = fee.split();
+        let (maker_fee, taker_fee) = fee.split();
 
         assert_eq!(fee.as_u64(), 3);
-        assert_eq!(long_fee, 1);
-        assert_eq!(short_fee, 2);
-        assert!((long_fee + short_fee) as f64 >= SIGNED_VBYTES_TEST);
+        assert_eq!(maker_fee, 1);
+        assert_eq!(taker_fee, 2);
+        assert!((maker_fee + taker_fee) as f64 >= SIGNED_VBYTES_TEST);
     }
 }

--- a/tests/cfds.rs
+++ b/tests/cfds.rs
@@ -22,11 +22,11 @@ use std::str::FromStr;
 fn create_cfd() {
     let mut rng = thread_rng();
 
-    let long_lock_amount = Amount::ONE_BTC;
-    let short_lock_amount = Amount::ONE_BTC;
+    let maker_lock_amount = Amount::ONE_BTC;
+    let taker_lock_amount = Amount::ONE_BTC;
 
-    let long_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
-    let short_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
+    let maker_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
+    let taker_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
 
     let oracle_data_0 = OliviaData::example_0();
     let oracle_data_1 = OliviaData::example_1();
@@ -64,32 +64,32 @@ fn create_cfd() {
     let cet_timelock = 0;
     let refund_timelock = 0;
 
-    let (long_cfd_txs, short_cfd_txs, long, short, long_addr, short_addr) = create_cfd_txs(
+    let (maker_cfd_txs, taker_cfd_txs, maker, taker, maker_addr, taker_addr) = create_cfd_txs(
         &mut rng,
-        (&long_wallet, long_lock_amount),
-        (&short_wallet, short_lock_amount),
+        (&maker_wallet, maker_lock_amount),
+        (&taker_wallet, taker_lock_amount),
         oracle_pk,
         payouts_per_event,
         (cet_timelock, refund_timelock),
     );
 
-    assert_contains_cets_for_event(&long_cfd_txs.cets, &event_0);
-    assert_contains_cets_for_event(&long_cfd_txs.cets, &event_1);
-    assert_contains_cets_for_event(&short_cfd_txs.cets, &event_0);
-    assert_contains_cets_for_event(&short_cfd_txs.cets, &event_1);
+    assert_contains_cets_for_event(&maker_cfd_txs.cets, &event_0);
+    assert_contains_cets_for_event(&maker_cfd_txs.cets, &event_1);
+    assert_contains_cets_for_event(&taker_cfd_txs.cets, &event_0);
+    assert_contains_cets_for_event(&taker_cfd_txs.cets, &event_1);
 
-    let lock_desc = lock_descriptor(long.pk, short.pk);
-    let lock_amount = long_lock_amount + short_lock_amount;
+    let lock_desc = lock_descriptor(maker.pk, taker.pk);
+    let lock_amount = maker_lock_amount + taker_lock_amount;
 
     let commit_desc = commit_descriptor(
-        (long.pk, long.rev_pk, long.pub_pk),
-        (short.pk, short.rev_pk, short.pub_pk),
+        (maker.pk, maker.rev_pk, maker.pub_pk),
+        (taker.pk, taker.rev_pk, taker.pub_pk),
     );
-    let commit_amount = Amount::from_sat(long_cfd_txs.commit.0.output[0].value);
+    let commit_amount = Amount::from_sat(maker_cfd_txs.commit.0.output[0].value);
 
     verify_cfd_sigs(
-        (&long_cfd_txs, long.pk, long.pub_pk),
-        (&short_cfd_txs, short.pk, short.pub_pk),
+        (&maker_cfd_txs, maker.pk, maker.pub_pk),
+        (&taker_cfd_txs, taker.pk, taker.pub_pk),
         (oracle_pk, vec![event_0, event_1]),
         (&lock_desc, lock_amount),
         (&commit_desc, commit_amount),
@@ -97,24 +97,24 @@ fn create_cfd() {
 
     check_cfd_txs(
         (
-            long_wallet,
-            long_cfd_txs,
-            long.sk,
-            long.pk,
-            long.pub_sk,
-            long.pub_pk,
-            long.rev_sk,
-            long_addr,
+            maker_wallet,
+            maker_cfd_txs,
+            maker.sk,
+            maker.pk,
+            maker.pub_sk,
+            maker.pub_pk,
+            maker.rev_sk,
+            maker_addr,
         ),
         (
-            short_wallet,
-            short_cfd_txs,
-            short.sk,
-            short.pk,
-            short.pub_sk,
-            short.pub_pk,
-            short.rev_sk,
-            short_addr,
+            taker_wallet,
+            taker_cfd_txs,
+            taker.sk,
+            taker.pk,
+            taker.pub_sk,
+            taker.pub_pk,
+            taker.rev_sk,
+            taker_addr,
         ),
         &[oracle_data_0, oracle_data_1],
         (lock_desc, lock_amount),
@@ -126,11 +126,11 @@ fn create_cfd() {
 fn renew_cfd() {
     let mut rng = thread_rng();
 
-    let long_lock_amount = Amount::ONE_BTC;
-    let short_lock_amount = Amount::ONE_BTC;
+    let maker_lock_amount = Amount::ONE_BTC;
+    let taker_lock_amount = Amount::ONE_BTC;
 
-    let long_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
-    let short_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
+    let maker_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
+    let taker_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
 
     let oracle_data = OliviaData::example_0();
     let oracle_pk = oracle_data.pk;
@@ -153,10 +153,10 @@ fn renew_cfd() {
     let cet_timelock = 0;
     let refund_timelock = 0;
 
-    let (long_cfd_txs, short_cfd_txs, long, short, long_addr, short_addr) = create_cfd_txs(
+    let (maker_cfd_txs, taker_cfd_txs, maker, taker, maker_addr, taker_addr) = create_cfd_txs(
         &mut rng,
-        (&long_wallet, long_lock_amount),
-        (&short_wallet, short_lock_amount),
+        (&maker_wallet, maker_lock_amount),
+        (&taker_wallet, taker_lock_amount),
         oracle_pk,
         payouts_per_event,
         (cet_timelock, refund_timelock),
@@ -164,11 +164,11 @@ fn renew_cfd() {
 
     // renew cfd transactions
 
-    let (long_rev_sk, long_rev_pk) = make_keypair(&mut rng);
-    let (long_pub_sk, long_pub_pk) = make_keypair(&mut rng);
+    let (maker_rev_sk, maker_rev_pk) = make_keypair(&mut rng);
+    let (maker_pub_sk, maker_pub_pk) = make_keypair(&mut rng);
 
-    let (short_rev_sk, short_rev_pk) = make_keypair(&mut rng);
-    let (short_pub_sk, short_pub_pk) = make_keypair(&mut rng);
+    let (taker_rev_sk, taker_rev_pk) = make_keypair(&mut rng);
+    let (taker_pub_sk, taker_pub_pk) = make_keypair(&mut rng);
 
     let oracle_data = OliviaData::example_1();
     let oracle_pk = oracle_data.pk;
@@ -193,77 +193,77 @@ fn renew_cfd() {
         .concat(),
     )]);
 
-    let long_cfd_txs = renew_cfd_transactions(
-        long_cfd_txs.lock,
+    let maker_cfd_txs = renew_cfd_transactions(
+        maker_cfd_txs.lock,
         (
-            long.pk,
-            long_lock_amount,
-            long_addr.clone(),
+            maker.pk,
+            maker_lock_amount,
+            maker_addr.clone(),
             PunishParams {
-                revocation_pk: long_rev_pk,
-                publish_pk: long_pub_pk,
+                revocation_pk: maker_rev_pk,
+                publish_pk: maker_pub_pk,
             },
         ),
         (
-            short.pk,
-            short_lock_amount,
-            short_addr.clone(),
+            taker.pk,
+            taker_lock_amount,
+            taker_addr.clone(),
             PunishParams {
-                revocation_pk: short_rev_pk,
-                publish_pk: short_pub_pk,
+                revocation_pk: taker_rev_pk,
+                publish_pk: taker_pub_pk,
             },
         ),
         oracle_pk,
         (cet_timelock, refund_timelock),
         payouts_per_event.clone(),
-        long.sk,
+        maker.sk,
         1,
     )
     .unwrap();
 
-    let short_cfd_txs = renew_cfd_transactions(
-        short_cfd_txs.lock,
+    let taker_cfd_txs = renew_cfd_transactions(
+        taker_cfd_txs.lock,
         (
-            long.pk,
-            long_lock_amount,
-            long_addr.clone(),
+            maker.pk,
+            maker_lock_amount,
+            maker_addr.clone(),
             PunishParams {
-                revocation_pk: long_rev_pk,
-                publish_pk: long_pub_pk,
+                revocation_pk: maker_rev_pk,
+                publish_pk: maker_pub_pk,
             },
         ),
         (
-            short.pk,
-            short_lock_amount,
-            short_addr.clone(),
+            taker.pk,
+            taker_lock_amount,
+            taker_addr.clone(),
             PunishParams {
-                revocation_pk: short_rev_pk,
-                publish_pk: short_pub_pk,
+                revocation_pk: taker_rev_pk,
+                publish_pk: taker_pub_pk,
             },
         ),
         oracle_pk,
         (cet_timelock, refund_timelock),
         payouts_per_event,
-        short.sk,
+        taker.sk,
         1,
     )
     .unwrap();
 
-    assert_contains_cets_for_event(&long_cfd_txs.cets, &event);
-    assert_contains_cets_for_event(&short_cfd_txs.cets, &event);
+    assert_contains_cets_for_event(&maker_cfd_txs.cets, &event);
+    assert_contains_cets_for_event(&taker_cfd_txs.cets, &event);
 
-    let lock_desc = lock_descriptor(long.pk, short.pk);
-    let lock_amount = long_lock_amount + short_lock_amount;
+    let lock_desc = lock_descriptor(maker.pk, taker.pk);
+    let lock_amount = maker_lock_amount + taker_lock_amount;
 
     let commit_desc = commit_descriptor(
-        (long.pk, long_rev_pk, long_pub_pk),
-        (short.pk, short_rev_pk, short_pub_pk),
+        (maker.pk, maker_rev_pk, maker_pub_pk),
+        (taker.pk, taker_rev_pk, taker_pub_pk),
     );
-    let commit_amount = Amount::from_sat(long_cfd_txs.commit.0.output[0].value);
+    let commit_amount = Amount::from_sat(maker_cfd_txs.commit.0.output[0].value);
 
     verify_cfd_sigs(
-        (&long_cfd_txs, long.pk, long_pub_pk),
-        (&short_cfd_txs, short.pk, short_pub_pk),
+        (&maker_cfd_txs, maker.pk, maker_pub_pk),
+        (&taker_cfd_txs, taker.pk, taker_pub_pk),
         (oracle_pk, vec![event]),
         (&lock_desc, lock_amount),
         (&commit_desc, commit_amount),
@@ -271,24 +271,24 @@ fn renew_cfd() {
 
     check_cfd_txs(
         (
-            long_wallet,
-            long_cfd_txs,
-            long.sk,
-            long.pk,
-            long_pub_sk,
-            long_pub_pk,
-            long_rev_sk,
-            long_addr,
+            maker_wallet,
+            maker_cfd_txs,
+            maker.sk,
+            maker.pk,
+            maker_pub_sk,
+            maker_pub_pk,
+            maker_rev_sk,
+            maker_addr,
         ),
         (
-            short_wallet,
-            short_cfd_txs,
-            short.sk,
-            short.pk,
-            short_pub_sk,
-            short_pub_pk,
-            short_rev_sk,
-            short_addr,
+            taker_wallet,
+            taker_cfd_txs,
+            taker.sk,
+            taker.pk,
+            taker_pub_sk,
+            taker_pub_pk,
+            taker_rev_sk,
+            taker_addr,
         ),
         &[oracle_data],
         (lock_desc, lock_amount),
@@ -300,11 +300,11 @@ fn renew_cfd() {
 fn collaboratively_close_cfd() {
     let mut rng = thread_rng();
 
-    let long_lock_amount = Amount::ONE_BTC;
-    let short_lock_amount = Amount::ONE_BTC;
+    let maker_lock_amount = Amount::ONE_BTC;
+    let taker_lock_amount = Amount::ONE_BTC;
 
-    let long_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
-    let short_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
+    let maker_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
+    let taker_wallet = build_wallet(&mut rng, Amount::from_btc(0.4).unwrap(), 5).unwrap();
 
     let oracle_data = OliviaData::example_0();
     let oracle_pk = oracle_data.pk;
@@ -323,17 +323,17 @@ fn collaboratively_close_cfd() {
     let cet_timelock = 0;
     let refund_timelock = 0;
 
-    let (long_cfd_txs, _, long, short, long_addr, short_addr) = create_cfd_txs(
+    let (maker_cfd_txs, _, maker, taker, maker_addr, taker_addr) = create_cfd_txs(
         &mut rng,
-        (&long_wallet, long_lock_amount),
-        (&short_wallet, short_lock_amount),
+        (&maker_wallet, maker_lock_amount),
+        (&taker_wallet, taker_lock_amount),
         oracle_pk,
         payouts_per_event,
         (cet_timelock, refund_timelock),
     );
 
-    let lock_tx = long_cfd_txs.lock.extract_tx();
-    let lock_desc = lock_descriptor(long.pk, short.pk);
+    let lock_tx = maker_cfd_txs.lock.extract_tx();
+    let lock_desc = lock_descriptor(maker.pk, taker.pk);
     let (lock_outpoint, lock_amount) = {
         let outpoint = lock_tx
             .outpoint(&lock_desc.script_pubkey())
@@ -343,26 +343,26 @@ fn collaboratively_close_cfd() {
         (outpoint, amount)
     };
 
-    let long_amount = Amount::ONE_BTC;
-    let short_amount = Amount::ONE_BTC;
+    let maker_amount = Amount::ONE_BTC;
+    let taker_amount = Amount::ONE_BTC;
 
     let (close_tx, close_sighash) = close_transaction(
         &lock_desc,
         lock_outpoint,
         lock_amount,
-        (&long_addr, long_amount),
-        (&short_addr, short_amount),
+        (&maker_addr, maker_amount),
+        (&taker_addr, taker_amount),
         1,
     )
     .expect("to build close tx");
 
-    let sig_long = SECP256K1.sign(&close_sighash, &long.sk);
-    let sig_short = SECP256K1.sign(&close_sighash, &short.sk);
+    let sig_maker = SECP256K1.sign(&close_sighash, &maker.sk);
+    let sig_taker = SECP256K1.sign(&close_sighash, &taker.sk);
     let signed_close_tx = finalize_spend_transaction(
         close_tx,
         &lock_desc,
-        (long.pk, sig_long),
-        (short.pk, sig_short),
+        (maker.pk, sig_maker),
+        (taker.pk, sig_taker),
     )
     .expect("to sign close tx");
 
@@ -371,8 +371,8 @@ fn collaboratively_close_cfd() {
 
 fn create_cfd_txs(
     rng: &mut (impl RngCore + CryptoRng),
-    (long_wallet, long_lock_amount): (&bdk::Wallet<(), bdk::database::MemoryDatabase>, Amount),
-    (short_wallet, short_lock_amount): (&bdk::Wallet<(), bdk::database::MemoryDatabase>, Amount),
+    (maker_wallet, maker_lock_amount): (&bdk::Wallet<(), bdk::database::MemoryDatabase>, Amount),
+    (taker_wallet, taker_lock_amount): (&bdk::Wallet<(), bdk::database::MemoryDatabase>, Amount),
     oracle_pk: schnorrsig::PublicKey,
     payouts_per_event: HashMap<Announcement, Vec<Payout>>,
     (cet_timelock, refund_timelock): (u32, u32),
@@ -384,112 +384,112 @@ fn create_cfd_txs(
     Address,
     Address,
 ) {
-    let (long_sk, long_pk) = make_keypair(rng);
-    let (short_sk, short_pk) = make_keypair(rng);
+    let (maker_sk, maker_pk) = make_keypair(rng);
+    let (taker_sk, taker_pk) = make_keypair(rng);
 
-    let long_addr = long_wallet.get_address(AddressIndex::New).unwrap();
-    let short_addr = short_wallet.get_address(AddressIndex::New).unwrap();
+    let maker_addr = maker_wallet.get_address(AddressIndex::New).unwrap();
+    let taker_addr = taker_wallet.get_address(AddressIndex::New).unwrap();
 
-    let (long_rev_sk, long_rev_pk) = make_keypair(rng);
-    let (long_pub_sk, long_pub_pk) = make_keypair(rng);
-    let (short_rev_sk, short_rev_pk) = make_keypair(rng);
-    let (short_pub_sk, short_pub_pk) = make_keypair(rng);
+    let (maker_rev_sk, maker_rev_pk) = make_keypair(rng);
+    let (maker_pub_sk, maker_pub_pk) = make_keypair(rng);
+    let (taker_rev_sk, taker_rev_pk) = make_keypair(rng);
+    let (taker_pub_sk, taker_pub_pk) = make_keypair(rng);
 
-    let long_params = PartyParams {
+    let maker_params = PartyParams {
         lock_psbt: {
-            let mut builder = long_wallet.build_tx();
+            let mut builder = maker_wallet.build_tx();
 
             builder
                 .fee_rate(FeeRate::from_sat_per_vb(1.0))
-                .add_2of2_multisig_recipient(long_lock_amount);
+                .add_2of2_multisig_recipient(maker_lock_amount);
 
             builder.finish().unwrap().0
         },
-        identity_pk: long_pk,
-        lock_amount: long_lock_amount,
-        address: long_wallet.get_address(AddressIndex::New).unwrap().address,
+        identity_pk: maker_pk,
+        lock_amount: maker_lock_amount,
+        address: maker_wallet.get_address(AddressIndex::New).unwrap().address,
     };
 
-    let short_params = PartyParams {
+    let taker_params = PartyParams {
         lock_psbt: {
-            let mut builder = short_wallet.build_tx();
+            let mut builder = taker_wallet.build_tx();
 
             builder
                 .fee_rate(FeeRate::from_sat_per_vb(1.0))
-                .add_2of2_multisig_recipient(short_lock_amount);
+                .add_2of2_multisig_recipient(taker_lock_amount);
 
             builder.finish().unwrap().0
         },
-        identity_pk: short_pk,
-        lock_amount: short_lock_amount,
-        address: short_wallet.get_address(AddressIndex::New).unwrap().address,
+        identity_pk: taker_pk,
+        lock_amount: taker_lock_amount,
+        address: taker_wallet.get_address(AddressIndex::New).unwrap().address,
     };
 
-    let long_cfd_txs = create_cfd_transactions(
+    let maker_cfd_txs = create_cfd_transactions(
         (
-            long_params.clone(),
+            maker_params.clone(),
             PunishParams {
-                revocation_pk: long_rev_pk,
-                publish_pk: long_pub_pk,
+                revocation_pk: maker_rev_pk,
+                publish_pk: maker_pub_pk,
             },
         ),
         (
-            short_params.clone(),
+            taker_params.clone(),
             PunishParams {
-                revocation_pk: short_rev_pk,
-                publish_pk: short_pub_pk,
+                revocation_pk: taker_rev_pk,
+                publish_pk: taker_pub_pk,
             },
         ),
         oracle_pk,
         (cet_timelock, refund_timelock),
         payouts_per_event.clone(),
-        long_sk,
+        maker_sk,
         1,
     )
     .unwrap();
-    let short_cfd_txs = create_cfd_transactions(
+    let taker_cfd_txs = create_cfd_transactions(
         (
-            long_params,
+            maker_params,
             PunishParams {
-                revocation_pk: long_rev_pk,
-                publish_pk: long_pub_pk,
+                revocation_pk: maker_rev_pk,
+                publish_pk: maker_pub_pk,
             },
         ),
         (
-            short_params,
+            taker_params,
             PunishParams {
-                revocation_pk: short_rev_pk,
-                publish_pk: short_pub_pk,
+                revocation_pk: taker_rev_pk,
+                publish_pk: taker_pub_pk,
             },
         ),
         oracle_pk,
         (cet_timelock, refund_timelock),
         payouts_per_event,
-        short_sk,
+        taker_sk,
         1,
     )
     .unwrap();
     (
-        long_cfd_txs,
-        short_cfd_txs,
+        maker_cfd_txs,
+        taker_cfd_txs,
         CfdKeys {
-            sk: long_sk,
-            pk: long_pk,
-            rev_sk: long_rev_sk,
-            rev_pk: long_rev_pk,
-            pub_sk: long_pub_sk,
-            pub_pk: long_pub_pk,
+            sk: maker_sk,
+            pk: maker_pk,
+            rev_sk: maker_rev_sk,
+            rev_pk: maker_rev_pk,
+            pub_sk: maker_pub_sk,
+            pub_pk: maker_pub_pk,
         },
         CfdKeys {
-            sk: short_sk,
-            pk: short_pk,
-            rev_sk: short_rev_sk,
-            rev_pk: short_rev_pk,
-            pub_sk: short_pub_sk,
-            pub_pk: short_pub_pk,
+            sk: taker_sk,
+            pk: taker_pk,
+            rev_sk: taker_rev_sk,
+            rev_pk: taker_rev_pk,
+            pub_sk: taker_pub_sk,
+            pub_pk: taker_pub_pk,
         },
-        long_addr.address,
-        short_addr.address,
+        maker_addr.address,
+        taker_addr.address,
     )
 }
 
@@ -503,121 +503,121 @@ struct CfdKeys {
 }
 
 fn verify_cfd_sigs(
-    (long_cfd_txs, long_pk, long_publish_pk): (&CfdTransactions, PublicKey, PublicKey),
-    (short_cfd_txs, short_pk, short_publish_pk): (&CfdTransactions, PublicKey, PublicKey),
+    (maker_cfd_txs, maker_pk, maker_publish_pk): (&CfdTransactions, PublicKey, PublicKey),
+    (taker_cfd_txs, taker_pk, taker_publish_pk): (&CfdTransactions, PublicKey, PublicKey),
     (oracle_pk, events): (schnorrsig::PublicKey, Vec<Announcement>),
     (lock_desc, lock_amount): (&Descriptor<PublicKey>, Amount),
     (commit_desc, commit_amount): (&Descriptor<PublicKey>, Amount),
 ) {
     verify_spend(
-        &short_cfd_txs.refund.0,
-        &long_cfd_txs.refund.1,
+        &taker_cfd_txs.refund.0,
+        &maker_cfd_txs.refund.1,
         commit_desc,
         commit_amount,
-        &long_pk.key,
+        &maker_pk.key,
     )
-    .expect("valid long refund sig");
+    .expect("valid maker refund sig");
     verify_spend(
-        &long_cfd_txs.refund.0,
-        &short_cfd_txs.refund.1,
+        &maker_cfd_txs.refund.0,
+        &taker_cfd_txs.refund.1,
         commit_desc,
         commit_amount,
-        &short_pk.key,
+        &taker_pk.key,
     )
-    .expect("valid short refund sig");
+    .expect("valid taker refund sig");
 
-    for grouped_short_cets in short_cfd_txs.cets.iter() {
-        let grouped_long_cets = long_cfd_txs
+    for grouped_taker_cets in taker_cfd_txs.cets.iter() {
+        let grouped_maker_cets = maker_cfd_txs
             .cets
             .iter()
-            .find(|grouped_long_cets| grouped_long_cets.event == grouped_short_cets.event)
+            .find(|grouped_maker_cets| grouped_maker_cets.event == grouped_taker_cets.event)
             .expect("both parties to have the same set of payouts");
         let event = events
             .iter()
-            .find(|event| event.id == grouped_long_cets.event.id)
+            .find(|event| event.id == grouped_maker_cets.event.id)
             .expect("event to exist");
-        for (tx, _, digits) in grouped_short_cets.cets.iter() {
-            grouped_long_cets
+        for (tx, _, digits) in grouped_taker_cets.cets.iter() {
+            grouped_maker_cets
                 .cets
                 .iter()
-                .find(|(long_tx, long_encsig, _)| {
-                    long_tx.txid() == tx.txid()
+                .find(|(maker_tx, maker_encsig, _)| {
+                    maker_tx.txid() == tx.txid()
                         && verify_cet_encsig(
                             tx,
-                            long_encsig,
+                            maker_encsig,
                             digits,
-                            &long_pk.key,
+                            &maker_pk.key,
                             (oracle_pk, event.nonce_pks.as_slice()),
                             commit_desc,
                             commit_amount,
                         )
                         .is_ok()
                 })
-                .expect("one valid long cet encsig per cet");
+                .expect("one valid maker cet encsig per cet");
         }
     }
 
-    for grouped_long_cets in long_cfd_txs.cets.iter() {
-        let grouped_short_cets = short_cfd_txs
+    for grouped_maker_cets in maker_cfd_txs.cets.iter() {
+        let grouped_taker_cets = taker_cfd_txs
             .cets
             .iter()
-            .find(|grouped_short_cets| grouped_short_cets.event == grouped_long_cets.event)
+            .find(|grouped_taker_cets| grouped_taker_cets.event == grouped_maker_cets.event)
             .expect("both parties to have the same set of payouts");
         let event = events
             .iter()
-            .find(|event| event.id == grouped_long_cets.event.id)
+            .find(|event| event.id == grouped_maker_cets.event.id)
             .expect("event to exist");
-        for (tx, _, digits) in grouped_long_cets.cets.iter() {
-            grouped_short_cets
+        for (tx, _, digits) in grouped_maker_cets.cets.iter() {
+            grouped_taker_cets
                 .cets
                 .iter()
-                .find(|(short_tx, short_encsig, _)| {
-                    short_tx.txid() == tx.txid()
+                .find(|(taker_tx, taker_encsig, _)| {
+                    taker_tx.txid() == tx.txid()
                         && verify_cet_encsig(
                             tx,
-                            short_encsig,
+                            taker_encsig,
                             digits,
-                            &short_pk.key,
+                            &taker_pk.key,
                             (oracle_pk, event.nonce_pks.as_slice()),
                             commit_desc,
                             commit_amount,
                         )
                         .is_ok()
                 })
-                .expect("one valid short cet encsig per cet");
+                .expect("one valid taker cet encsig per cet");
         }
     }
 
     encverify_spend(
-        &short_cfd_txs.commit.0,
-        &long_cfd_txs.commit.1,
+        &taker_cfd_txs.commit.0,
+        &maker_cfd_txs.commit.1,
         lock_desc,
         lock_amount,
-        &short_publish_pk.key,
-        &long_pk.key,
+        &taker_publish_pk.key,
+        &maker_pk.key,
     )
-    .expect("valid long commit encsig");
+    .expect("valid maker commit encsig");
     encverify_spend(
-        &long_cfd_txs.commit.0,
-        &short_cfd_txs.commit.1,
+        &maker_cfd_txs.commit.0,
+        &taker_cfd_txs.commit.1,
         lock_desc,
         lock_amount,
-        &long_publish_pk.key,
-        &short_pk.key,
+        &maker_publish_pk.key,
+        &taker_pk.key,
     )
-    .expect("valid short commit encsig");
+    .expect("valid taker commit encsig");
 }
 
 fn check_cfd_txs(
     (
-long_wallet,
-long_cfd_txs,
-long_sk,
-long_pk,
-long_pub_sk,
-long_pub_pk,
-long_rev_sk,
-long_addr,
+        maker_wallet,
+        maker_cfd_txs,
+        maker_sk,
+        maker_pk,
+        maker_pub_sk,
+        maker_pub_pk,
+        maker_rev_sk,
+        maker_addr,
     ): (
         bdk::Wallet<(), bdk::database::MemoryDatabase>,
         CfdTransactions,
@@ -629,14 +629,14 @@ long_addr,
         Address,
     ),
     (
-        short_wallet,
-        short_cfd_txs,
-        short_sk,
-        short_pk,
-        short_pub_sk,
-        short_pub_pk,
-        short_rev_sk,
-        short_addr,
+        taker_wallet,
+        taker_cfd_txs,
+        taker_sk,
+        taker_pk,
+        taker_pub_sk,
+        taker_pub_pk,
+        taker_rev_sk,
+        taker_addr,
     ): (
         bdk::Wallet<(), bdk::database::MemoryDatabase>,
         CfdTransactions,
@@ -653,48 +653,48 @@ long_addr,
 ) {
     // Lock transaction (either party can do this):
 
-    let signed_lock_tx = sign_lock_tx(long_cfd_txs.lock.clone(), long_wallet, short_wallet)
+    let signed_lock_tx = sign_lock_tx(maker_cfd_txs.lock.clone(), maker_wallet, taker_wallet)
         .expect("to build signed lock tx");
 
     // Commit transactions:
 
-    let signed_commit_tx_long = decrypt_and_sign(
-        long_cfd_txs.commit.0.clone(),
-        (&long_sk, &long_pk),
-        &long_pub_sk,
-        &short_pk,
-        &short_cfd_txs.commit.1,
+    let signed_commit_tx_maker = decrypt_and_sign(
+        maker_cfd_txs.commit.0.clone(),
+        (&maker_sk, &maker_pk),
+        &maker_pub_sk,
+        &taker_pk,
+        &taker_cfd_txs.commit.1,
         &lock_desc,
         lock_amount,
     )
-    .expect("long to build signed commit tx");
-    check_tx(&signed_lock_tx, &signed_commit_tx_long, &lock_desc).expect("valid long commit tx");
-    let signed_commit_tx_short = decrypt_and_sign(
-        short_cfd_txs.commit.0.clone(),
-        (&short_sk, &short_pk),
-        &short_pub_sk,
-        &long_pk,
-        &long_cfd_txs.commit.1,
+    .expect("maker to build signed commit tx");
+    check_tx(&signed_lock_tx, &signed_commit_tx_maker, &lock_desc).expect("valid maker commit tx");
+    let signed_commit_tx_taker = decrypt_and_sign(
+        taker_cfd_txs.commit.0.clone(),
+        (&taker_sk, &taker_pk),
+        &taker_pub_sk,
+        &maker_pk,
+        &maker_cfd_txs.commit.1,
         &lock_desc,
         lock_amount,
     )
-    .expect("short to build signed commit tx");
-    check_tx(&signed_lock_tx, &signed_commit_tx_short, &lock_desc).expect("valid short commit tx");
+    .expect("taker to build signed commit tx");
+    check_tx(&signed_lock_tx, &signed_commit_tx_taker, &lock_desc).expect("valid taker commit tx");
 
     // Refund transaction (both parties would produce the same one):
 
     let signed_refund_tx = finalize_spend_transaction(
-        long_cfd_txs.refund.0.clone(),
+        maker_cfd_txs.refund.0.clone(),
         &commit_desc,
-        (long_pk, long_cfd_txs.refund.1),
-        (short_pk, short_cfd_txs.refund.1),
+        (maker_pk, maker_cfd_txs.refund.1),
+        (taker_pk, taker_cfd_txs.refund.1),
     )
     .expect("to build signed refund tx");
-    check_tx(&signed_commit_tx_long, &signed_refund_tx, &commit_desc).expect("valid refund tx");
+    check_tx(&signed_commit_tx_maker, &signed_refund_tx, &commit_desc).expect("valid refund tx");
 
     // CETs:
 
-    for Cets { event, cets } in long_cfd_txs.cets.clone().into_iter() {
+    for Cets { event, cets } in maker_cfd_txs.cets.clone().into_iter() {
         let oracle_data = oracle_data_list
             .iter()
             .find(|data| data.id == event.id)
@@ -702,7 +702,7 @@ long_addr,
         let price = oracle_data.price;
         let oracle_attestations = oracle_data.attestations.clone();
 
-        let short_cets = short_cfd_txs
+        let taker_cets = taker_cfd_txs
             .cets
             .iter()
             .find_map(
@@ -711,7 +711,7 @@ long_addr,
                      cets,
                  }| (other_event.id == event.id).then(|| cets),
             )
-            .expect("same events for short and long");
+            .expect("same events for taker and maker");
 
         cets.into_iter().for_each(|(tx, _, digits)| {
             if !digits.range().contains(&price) {
@@ -720,17 +720,17 @@ long_addr,
 
             build_and_check_cet(
                 tx,
-                short_cets,
-                (&long_sk, &long_pk),
-                &short_pk,
+                taker_cets,
+                (&maker_sk, &maker_pk),
+                &taker_pk,
                 (price, &oracle_attestations),
-                (&signed_commit_tx_long, &commit_desc, commit_amount),
+                (&signed_commit_tx_maker, &commit_desc, commit_amount),
             )
-            .expect("valid unlocked long cet");
+            .expect("valid unlocked maker cet");
         });
     }
 
-    for Cets { event, cets } in short_cfd_txs.cets.clone().into_iter() {
+    for Cets { event, cets } in taker_cfd_txs.cets.clone().into_iter() {
         let oracle_data = oracle_data_list
             .iter()
             .find(|data| data.id == event.id)
@@ -738,7 +738,7 @@ long_addr,
         let price = oracle_data.price;
         let oracle_attestations = oracle_data.attestations.clone();
 
-        let long_cets = long_cfd_txs
+        let maker_cets = maker_cfd_txs
             .cets
             .iter()
             .find_map(
@@ -747,7 +747,7 @@ long_addr,
                      cets,
                  }| (other_event.id == event.id).then(|| cets),
             )
-            .expect("same events for short and long");
+            .expect("same events for taker and maker");
 
         cets.into_iter().for_each(|(tx, _, digits)| {
             if !digits.range().contains(&price) {
@@ -756,41 +756,42 @@ long_addr,
 
             build_and_check_cet(
                 tx,
-                long_cets,
-                (&short_sk, &short_pk),
-                &long_pk,
+                maker_cets,
+                (&taker_sk, &taker_pk),
+                &maker_pk,
                 (price, &oracle_attestations),
-                (&signed_commit_tx_short, &commit_desc, commit_amount),
+                (&signed_commit_tx_taker, &commit_desc, commit_amount),
             )
-            .expect("valid unlocked short cet");
+            .expect("valid unlocked taker cet");
         });
     }
 
     // Punish transactions:
 
-    let punish_tx_long = punish_transaction(
+    let punish_tx_maker = punish_transaction(
         &commit_desc,
-        &long_addr,
-        long_cfd_txs.commit.1,
-        long_sk,
-        short_rev_sk,
-        short_pub_pk,
-        &signed_commit_tx_short,
+        &maker_addr,
+        maker_cfd_txs.commit.1,
+        maker_sk,
+        taker_rev_sk,
+        taker_pub_pk,
+        &signed_commit_tx_taker,
     )
-    .expect("long to build punish tx");
-    check_tx(&signed_commit_tx_short, &punish_tx_long, &commit_desc).expect("valid long punish tx");
-    let punish_tx_short = punish_transaction(
+    .expect("maker to build punish tx");
+    check_tx(&signed_commit_tx_taker, &punish_tx_maker, &commit_desc)
+        .expect("valid maker punish tx");
+    let punish_tx_taker = punish_transaction(
         &commit_desc,
-        &short_addr,
-        short_cfd_txs.commit.1,
-        short_sk,
-        long_rev_sk,
-        long_pub_pk,
-        &signed_commit_tx_long,
+        &taker_addr,
+        taker_cfd_txs.commit.1,
+        taker_sk,
+        maker_rev_sk,
+        maker_pub_pk,
+        &signed_commit_tx_maker,
     )
-    .expect("short to build punish tx");
-    check_tx(&signed_commit_tx_long, &punish_tx_short, &commit_desc)
-        .expect("valid short punish tx");
+    .expect("taker to build punish tx");
+    check_tx(&signed_commit_tx_maker, &punish_tx_taker, &commit_desc)
+        .expect("valid taker punish tx");
 }
 
 fn build_and_check_cet(
@@ -886,10 +887,10 @@ fn decrypt_and_sign(
 
 fn sign_lock_tx(
     mut lock_tx: PartiallySignedTransaction,
-    long_wallet: bdk::Wallet<(), bdk::database::MemoryDatabase>,
-    short_wallet: bdk::Wallet<(), bdk::database::MemoryDatabase>,
+    maker_wallet: bdk::Wallet<(), bdk::database::MemoryDatabase>,
+    taker_wallet: bdk::Wallet<(), bdk::database::MemoryDatabase>,
 ) -> Result<Transaction> {
-    long_wallet
+    maker_wallet
         .sign(
             &mut lock_tx,
             SignOptions {
@@ -897,8 +898,8 @@ fn sign_lock_tx(
                 ..Default::default()
             },
         )
-        .context("long could not sign lock tx")?;
-    short_wallet
+        .context("maker could not sign lock tx")?;
+    taker_wallet
         .sign(
             &mut lock_tx,
             SignOptions {
@@ -906,7 +907,7 @@ fn sign_lock_tx(
                 ..Default::default()
             },
         )
-        .context("short could not sign lock tx")?;
+        .context("taker could not sign lock tx")?;
 
     Ok(lock_tx.extract_tx())
 }


### PR DESCRIPTION
Reverts comit-network/maia#21

I'd like to upgrade `bdk` and `secp256k1-zkp`, now that they are released AND actually use it in `itchysats`. However, we cannot do that because the current HEAD of `maia` does not work with `itchysats` because we would have to change the event models for adopting this rename and that is not possible before https://github.com/itchysats/architecture/issues/3 is _implemented_ which requires https://github.com/itchysats/itchysats/issues/1651 to be started.