### PR TITLE
Upgrade bdk and bitcoin in backwards-compatible fashion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb4ab7649b7ee7e170ea6dc3b7a3fc5d97671600fe40f6ffde3abe52ef4ae5"
+checksum = "ec2c4c49915b82a2576bc7dee83d2f274387904b79305e6ae8b622daa0b282c1"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -83,23 +83,17 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.27.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
+checksum = "05bba324e6baf655b882df672453dbbc527bc938cadd27750ae510aaccc3a66a"
 dependencies = [
  "base64-compat",
  "bech32",
- "bitcoin_hashes 0.10.0",
+ "bitcoin_hashes",
  "bitcoinconsensus",
  "secp256k1",
  "serde",
 ]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -248,7 +242,7 @@ dependencies = [
  "bdk",
  "bitcoin",
  "itertools",
- "maia-core 0.1.0 (git+https://github.com/comit-network/maia?rev=e419cb2cf19bed6ec53eaa3672408a6205a9b705)",
+ "maia-core 0.1.0 (git+https://github.com/comit-network/maia?tag=0.1.1)",
  "proptest",
  "rand 0.6.5",
  "secp256k1-zkp",
@@ -271,7 +265,7 @@ dependencies = [
 [[package]]
 name = "maia-core"
 version = "0.1.0"
-source = "git+https://github.com/comit-network/maia?rev=e419cb2cf19bed6ec53eaa3672408a6205a9b705#e419cb2cf19bed6ec53eaa3672408a6205a9b705"
+source = "git+https://github.com/comit-network/maia?tag=0.1.1#a577add9818a8ada012e0d4dc605c6cca585db0d"
 dependencies = [
  "anyhow",
  "bdk",
@@ -282,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "6.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e292b58407dfbf1384e5aca8428d3b0f2eaa09d24cb17088f6db0b7ca31194a"
+checksum = "da39fc7a8adea97a677337b0091779dd86349226b869053af496584a9b9e5847"
 dependencies = [
  "bitcoin",
  "serde",
@@ -561,11 +555,11 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
+checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
 dependencies = [
- "bitcoin_hashes 0.9.7",
+ "bitcoin_hashes",
  "rand 0.6.5",
  "secp256k1-sys",
  "serde",
@@ -573,18 +567,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
+checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "secp256k1-zkp"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e2709b09561dfb584b366bd418ee5549a858873baa707ed83d3eb986e34abf"
+checksum = "c724fda6aae465ed9a39320202bc6164e0adb3cdf9bc16d5af4be7eebaba75e5"
 dependencies = [
  "rand 0.6.5",
  "secp256k1",
@@ -594,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-zkp-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c48e70d04fdd871498db6ac3b35eeae0a339ab1cd06af483fe8a6835d36def"
+checksum = "e6f880412a627e79d3ce17355150ea1e0e76570efb7f0f70df51504cbe2582e3"
 dependencies = [
  "cc",
  "secp256k1-sys",

--- a/maia-core/Cargo.toml
+++ b/maia-core/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.18", default-features = false }
+bdk = { version = "0.19", default-features = false }
 bit-vec = "0.6"
-secp256k1-zkp = { version = "0.5", features = ["bitcoin_hashes", "global-context", "serde"] }
+secp256k1-zkp = { version = "0.6", features = ["bitcoin_hashes", "global-context", "serde"] }
 thiserror = "1"
 
 [dev-dependencies]
-bitcoin = { version = "0.27", features = ["rand", "bitcoinconsensus"] }
+bitcoin = { version = "0.28.1", features = ["rand", "bitcoinconsensus"] }
 proptest = { version = "1", default-features = false, features = ["std"] }

--- a/maia-core/src/protocol.rs
+++ b/maia-core/src/protocol.rs
@@ -10,8 +10,9 @@ pub use transaction_ext::TransactionExt;
 mod transaction_ext;
 
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
-use bdk::bitcoin::{Address, Amount, PublicKey, Transaction};
-use secp256k1_zkp::{schnorrsig, EcdsaAdaptorSignature, Signature};
+use bdk::bitcoin::{Address, Amount, PublicKey, Transaction, XOnlyPublicKey};
+use secp256k1_zkp::ecdsa::Signature;
+use secp256k1_zkp::EcdsaAdaptorSignature;
 
 use crate::interval;
 
@@ -75,7 +76,7 @@ pub struct Cets {
 #[derive(Debug, Clone, Eq)]
 pub struct Announcement {
     pub id: String,
-    pub nonce_pks: Vec<schnorrsig::PublicKey>,
+    pub nonce_pks: Vec<XOnlyPublicKey>,
 }
 
 impl std::hash::Hash for Announcement {

--- a/maia-core/src/protocol/transaction_ext.rs
+++ b/maia-core/src/protocol/transaction_ext.rs
@@ -8,7 +8,7 @@ pub trait TransactionExt {
 
 impl TransactionExt for Transaction {
     fn get_virtual_size(&self) -> f64 {
-        self.get_weight() as f64 / 4.0
+        self.weight() as f64 / 4.0
     }
 
     fn outpoint(&self, script_pubkey: &Script) -> Result<OutPoint> {

--- a/maia/Cargo.toml
+++ b/maia/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.18", default-features = false }
+bdk = { version = "0.19", default-features = false }
 itertools = "0.10"
-maia-core = { git = "https://github.com/comit-network/maia", rev = "e419cb2cf19bed6ec53eaa3672408a6205a9b705", package = "maia-core" } # Pin the maia-core version to before breaking change
+maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pin the maia-core version to latest v0.1 for backwards compatibility downstream
 rand = "0.6"
-secp256k1-zkp = { version = "0.5", features = ["bitcoin_hashes", "global-context", "serde"] }
+secp256k1-zkp = { version = "0.6", features = ["bitcoin_hashes", "global-context", "serde"] }
 thiserror = "1"
 
 [dev-dependencies]
-bitcoin = { version = "0.27", features = ["rand", "bitcoinconsensus"] }
+bitcoin = { version = "0.28.1", features = ["rand", "bitcoinconsensus"] }
 proptest = { version = "1", default-features = false, features = ["std"] }

--- a/maia/src/oracle.rs
+++ b/maia/src/oracle.rs
@@ -1,14 +1,13 @@
 pub use secp256k1_zkp::*;
 
 use anyhow::Result;
-use secp256k1_zkp::schnorrsig;
 use std::num::NonZeroU8;
 
 /// Compute an attestation public key for the given oracle public key,
 /// announcement nonce public key and outcome index.
 pub fn attestation_pk(
-    oracle_pk: &schnorrsig::PublicKey,
-    nonce_pk: &schnorrsig::PublicKey,
+    oracle_pk: &XOnlyPublicKey,
+    nonce_pk: &XOnlyPublicKey,
     index: NonZeroU8,
 ) -> Result<secp256k1_zkp::PublicKey> {
     let nonce_pk = schnorr_pubkey_to_pubkey(nonce_pk);
@@ -22,7 +21,7 @@ pub fn attestation_pk(
     Ok(attestation_pk)
 }
 
-fn schnorr_pubkey_to_pubkey(pk: &schnorrsig::PublicKey) -> secp256k1_zkp::PublicKey {
+fn schnorr_pubkey_to_pubkey(pk: &XOnlyPublicKey) -> secp256k1_zkp::PublicKey {
     let mut buf = Vec::<u8>::with_capacity(33);
 
     buf.push(0x02); // append even byte

--- a/maia/src/protocol.rs
+++ b/maia/src/protocol.rs
@@ -1,3 +1,4 @@
+use bdk::bitcoin::{EcdsaSig, EcdsaSighashType, XOnlyPublicKey};
 use maia_core::{Announcement, Cets, CfdTransactions, PartyParams, Payout, PunishParams};
 pub use transactions::{close_transaction, punish_transaction};
 
@@ -9,14 +10,15 @@ use crate::protocol::transactions::{
 };
 use anyhow::{bail, Context, Result};
 use bdk::bitcoin::hashes::hex::ToHex;
-use bdk::bitcoin::util::bip143::SigHashCache;
 use bdk::bitcoin::util::psbt::PartiallySignedTransaction;
-use bdk::bitcoin::{Address, Amount, PublicKey, SigHashType, Transaction};
+use bdk::bitcoin::util::sighash::SighashCache;
+use bdk::bitcoin::{Address, Amount, PublicKey, Transaction};
 use bdk::descriptor::Descriptor;
 use bdk::miniscript::descriptor::Wsh;
 use bdk::miniscript::DescriptorTrait;
 use itertools::Itertools;
-use secp256k1_zkp::{self, schnorrsig, SecretKey, Signature, SECP256K1};
+use secp256k1_zkp::ecdsa::Signature;
+use secp256k1_zkp::{self, SecretKey, SECP256K1};
 use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::num::NonZeroU8;
@@ -45,7 +47,7 @@ mod txin_ext;
 pub fn create_cfd_transactions(
     (maker, maker_punish_params): (PartyParams, PunishParams),
     (taker, taker_punish_params): (PartyParams, PunishParams),
-    oracle_pk: schnorrsig::PublicKey,
+    oracle_pk: XOnlyPublicKey,
     (cet_timelock, refund_timelock): (u32, u32),
     payouts_per_event: HashMap<Announcement, Vec<Payout>>,
     identity_sk: SecretKey,
@@ -96,7 +98,7 @@ pub fn renew_cfd_transactions(
         Address,
         PunishParams,
     ),
-    oracle_pk: schnorrsig::PublicKey,
+    oracle_pk: XOnlyPublicKey,
     (cet_timelock, refund_timelock): (u32, u32),
     payouts_per_event: HashMap<Announcement, Vec<Payout>>,
     identity_sk: SecretKey,
@@ -139,14 +141,14 @@ fn build_cfds(
         Address,
         PunishParams,
     ),
-    oracle_pk: schnorrsig::PublicKey,
+    oracle_pk: XOnlyPublicKey,
     (cet_timelock, refund_timelock): (u32, u32),
     payouts_per_event: HashMap<Announcement, Vec<Payout>>,
     identity_sk: SecretKey,
     commit_tx_fee_rate: u32,
 ) -> Result<CfdTransactions> {
     let commit_tx = CommitTransaction::new(
-        &lock_tx.global.unsigned_tx,
+        &lock_tx.unsigned_tx,
         (
             maker_pk,
             maker_punish_params.revocation_pk,
@@ -162,29 +164,27 @@ fn build_cfds(
     .context("cannot build commit tx")?;
 
     let identity_pk = secp256k1_zkp::PublicKey::from_secret_key(SECP256K1, &identity_sk);
-    let commit_encsig = if identity_pk == maker_pk.key {
+    let commit_encsig = if identity_pk == maker_pk.inner {
         commit_tx.encsign(identity_sk, &taker_punish_params.publish_pk)
-    } else if identity_pk == taker_pk.key {
+    } else if identity_pk == taker_pk.inner {
         commit_tx.encsign(identity_sk, &maker_punish_params.publish_pk)
     } else {
         bail!("identity sk does not belong to taker or maker")
     };
 
-    let refund = {
-        let tx = RefundTransaction::new(
-            &commit_tx,
-            refund_timelock,
-            &maker_address,
-            &taker_address,
-            maker_lock_amount,
-            taker_lock_amount,
-        );
+    let tx = RefundTransaction::new(
+        &commit_tx,
+        refund_timelock,
+        &maker_address,
+        &taker_address,
+        maker_lock_amount,
+        taker_lock_amount,
+    )?;
 
-        let sighash = tx.sighash().to_message();
-        let sig = SECP256K1.sign(&sighash, &identity_sk);
+    let sighash = tx.sighash().to_message();
+    let sig = SECP256K1.sign_ecdsa(&sighash, &identity_sk);
 
-        (tx.into_inner(), sig)
-    };
+    let refund = (tx.into_inner(), sig);
 
     let cets = payouts_per_event
         .into_iter()
@@ -223,8 +223,8 @@ fn build_cfds(
 pub fn lock_descriptor(maker_pk: PublicKey, taker_pk: PublicKey) -> Descriptor<PublicKey> {
     const MINISCRIPT_TEMPLATE: &str = "c:and_v(v:pk(A),pk_k(B))";
 
-    let maker_pk = ToHex::to_hex(&maker_pk.key);
-    let taker_pk = ToHex::to_hex(&taker_pk.key);
+    let maker_pk = ToHex::to_hex(&maker_pk.inner);
+    let taker_pk = ToHex::to_hex(&taker_pk.inner);
 
     let miniscript = MINISCRIPT_TEMPLATE
         .replace('A', &maker_pk)
@@ -240,12 +240,12 @@ pub fn commit_descriptor(
     (taker_own_pk, taker_rev_pk, taker_publish_pk): (PublicKey, PublicKey, PublicKey),
 ) -> Descriptor<PublicKey> {
     let maker_own_pk_hash = maker_own_pk.pubkey_hash().as_hash();
-    let maker_own_pk = maker_own_pk.key.serialize().to_hex();
+    let maker_own_pk = maker_own_pk.inner.serialize().to_hex();
     let maker_publish_pk_hash = maker_publish_pk.pubkey_hash().as_hash();
     let maker_rev_pk_hash = maker_rev_pk.pubkey_hash().as_hash();
 
     let taker_own_pk_hash = taker_own_pk.pubkey_hash().as_hash();
-    let taker_own_pk = taker_own_pk.key.serialize().to_hex();
+    let taker_own_pk = taker_own_pk.inner.serialize().to_hex();
     let taker_publish_pk_hash = taker_publish_pk.pubkey_hash().as_hash();
     let taker_rev_pk_hash = taker_rev_pk.pubkey_hash().as_hash();
 
@@ -270,14 +270,14 @@ pub fn spending_tx_sighash(
     spending_tx: &Transaction,
     spent_descriptor: &Descriptor<PublicKey>,
     spent_amount: Amount,
-) -> secp256k1_zkp::Message {
-    let sighash = SigHashCache::new(spending_tx).signature_hash(
+) -> Result<secp256k1_zkp::Message> {
+    let sighash = SighashCache::new(spending_tx).segwit_signature_hash(
         0,
-        &spent_descriptor.script_code(),
+        &spent_descriptor.script_code()?,
         spent_amount.as_sat(),
-        SigHashType::All,
-    );
-    sighash.to_message()
+        EcdsaSighashType::All,
+    )?;
+    Ok(sighash.to_message())
 }
 
 pub fn finalize_spend_transaction(
@@ -287,8 +287,20 @@ pub fn finalize_spend_transaction(
     (pk_1, sig_1): (PublicKey, Signature),
 ) -> Result<Transaction> {
     let satisfier = HashMap::from_iter(vec![
-        (pk_0, (sig_0, SigHashType::All)),
-        (pk_1, (sig_1, SigHashType::All)),
+        (
+            pk_0,
+            EcdsaSig {
+                sig: sig_0,
+                hash_ty: EcdsaSighashType::All,
+            },
+        ),
+        (
+            pk_1,
+            EcdsaSig {
+                sig: sig_1,
+                hash_ty: EcdsaSighashType::All,
+            },
+        ),
     ]);
 
     let input = tx
@@ -302,8 +314,8 @@ pub fn finalize_spend_transaction(
 }
 
 pub fn compute_adaptor_pk(
-    oracle_pk: &schnorrsig::PublicKey,
-    index_nonce_pairs: &[(NonZeroU8, schnorrsig::PublicKey)],
+    oracle_pk: &XOnlyPublicKey,
+    index_nonce_pairs: &[(NonZeroU8, XOnlyPublicKey)],
 ) -> Result<secp256k1_zkp::PublicKey> {
     let attestation_pks = index_nonce_pairs
         .iter()

--- a/maia/src/protocol/sighash_ext.rs
+++ b/maia/src/protocol/sighash_ext.rs
@@ -1,14 +1,13 @@
-use bdk::bitcoin::hashes::Hash;
-use bdk::bitcoin::SigHash;
+use bdk::bitcoin::Sighash;
 
 pub(crate) trait SigHashExt {
     fn to_message(self) -> secp256k1_zkp::Message;
 }
 
-impl SigHashExt for SigHash {
+impl SigHashExt for Sighash {
     fn to_message(self) -> secp256k1_zkp::Message {
-        use secp256k1_zkp::bitcoin_hashes::Hash;
-        let hash = secp256k1_zkp::bitcoin_hashes::sha256d::Hash::from_inner(*self.as_inner());
+        use secp256k1_zkp::hashes::Hash;
+        let hash = secp256k1_zkp::hashes::sha256d::Hash::from_inner(*self.as_inner());
 
         hash.into()
     }

--- a/maia/src/protocol/txin_ext.rs
+++ b/maia/src/protocol/txin_ext.rs
@@ -1,5 +1,5 @@
-use bdk::bitcoin::secp256k1::Signature;
 use bdk::bitcoin::TxIn;
+use secp256k1_zkp::ecdsa::Signature;
 
 pub(crate) trait TxInExt {
     fn find_map_signature<F, R>(&self, f: F) -> Option<R>
@@ -14,10 +14,7 @@ impl TxInExt for TxIn {
     {
         self.witness
             .iter()
-            .filter_map(|elem| {
-                let elem = elem.as_slice();
-                Signature::from_der(&elem[..elem.len() - 1]).ok()
-            })
+            .filter_map(|elem| Signature::from_der(&elem[..elem.len() - 1]).ok())
             .find_map(f)
     }
 }


### PR DESCRIPTION
Create a side branch `maia-0.1` with `0.1.1` quasi-release, which includes the latest dependency upgrades.

Merge that branch on top of 0.2 breaking-changes (and point `maia-core` version to `0.1.1`).