### PR TITLE
Bump bdk to 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bdk"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a0becbf5a97855daca6717ff920c52a779cebf655b23ae1427e5366d2661e82"
+dependencies = [
+ "async-trait",
+ "bdk-macros",
+ "bitcoin",
+ "js-sys",
+ "log",
+ "miniscript",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "bdk-macros"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,7 +257,7 @@ name = "maia"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "bdk",
+ "bdk 0.19.0",
  "bitcoin",
  "itertools",
  "maia-core 0.1.1 (git+https://github.com/comit-network/maia?tag=0.1.1)",
@@ -254,7 +272,7 @@ name = "maia-core"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "bdk",
+ "bdk 0.20.0",
  "bit-vec",
  "bitcoin",
  "proptest",
@@ -268,7 +286,7 @@ version = "0.1.1"
 source = "git+https://github.com/comit-network/maia?tag=0.1.1#e1354e9c0397326a99bb5068e3afbc8cf2e07a9d"
 dependencies = [
  "anyhow",
- "bdk",
+ "bdk 0.19.0",
  "bit-vec",
  "secp256k1-zkp",
  "thiserror",

--- a/maia-core/Cargo.toml
+++ b/maia-core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.19", default-features = false }
+bdk = { version = "0.20", default-features = false }
 bit-vec = "0.6"
 secp256k1-zkp = { version = "0.6", features = ["bitcoin_hashes", "global-context", "serde"] }
 thiserror = "1"

--- a/maia-core/Cargo.toml
+++ b/maia-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maia-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/maia/Cargo.toml
+++ b/maia/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.19", default-features = false }
+bdk = { version = "0.20", default-features = false }
 itertools = "0.10"
-maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pin the maia-core version to latest v0.1 for backwards compatibility downstream
+maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.2", package = "maia-core" } # Pin the maia-core version to latest v0.1 for backwards compatibility downstream
 rand = "0.6"
 secp256k1-zkp = { version = "0.6", features = ["bitcoin_hashes", "global-context", "serde"] }
 thiserror = "1"

--- a/maia/Cargo.toml
+++ b/maia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maia"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Builds on https://github.com/comit-network/maia/pull/45 and needs maia-core 0.1.2 to end in `main`