### PR TITLE
Bump BDK to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "bdk"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c4c49915b82a2576bc7dee83d2f274387904b79305e6ae8b622daa0b282c1"
+checksum = "3a7dad109193db0d196e9149bb56ba991aacfc1e1a2cf400053358b75f6c2fb5"
 dependencies = [
  "async-trait",
  "bdk-macros",
@@ -242,7 +242,7 @@ dependencies = [
  "bdk",
  "bitcoin",
  "itertools",
- "maia-core 0.1.1 (git+https://github.com/comit-network/maia?tag=0.1.1)",
+ "maia-core",
  "proptest",
  "rand 0.6.5",
  "secp256k1-zkp",
@@ -258,18 +258,6 @@ dependencies = [
  "bit-vec",
  "bitcoin",
  "proptest",
- "secp256k1-zkp",
- "thiserror",
-]
-
-[[package]]
-name = "maia-core"
-version = "0.1.1"
-source = "git+https://github.com/comit-network/maia?tag=0.1.1#e1354e9c0397326a99bb5068e3afbc8cf2e07a9d"
-dependencies = [
- "anyhow",
- "bdk",
- "bit-vec",
  "secp256k1-zkp",
  "thiserror",
 ]

--- a/maia-core/Cargo.toml
+++ b/maia-core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.19", default-features = false }
+bdk = { version = "0.21.0", default-features = false }
 bit-vec = "0.6"
 secp256k1-zkp = { version = "0.6", features = ["bitcoin_hashes", "global-context", "serde"] }
 thiserror = "1"

--- a/maia/Cargo.toml
+++ b/maia/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1"
 bdk = { version = "0.19", default-features = false }
 itertools = "0.10"
-maia-core = { git = "https://github.com/comit-network/maia", tag = "0.1.1", package = "maia-core" } # Pin the maia-core version to latest v0.1 for backwards compatibility downstream
+maia-core = { path = "../maia-core" }
 rand = "0.6"
 secp256k1-zkp = { version = "0.6", features = ["bitcoin_hashes", "global-context", "serde"] }
 thiserror = "1"

--- a/maia/Cargo.toml
+++ b/maia/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-bdk = { version = "0.19", default-features = false }
+bdk = { version = "0.21.0", default-features = false }
 itertools = "0.10"
 maia-core = { path = "../maia-core" }
 rand = "0.6"


### PR DESCRIPTION
Stop relying on maia-core 0.1, making it easier to upgrade maia moving forward.